### PR TITLE
added default image for apple touch devices

### DIFF
--- a/header.php
+++ b/header.php
@@ -9,6 +9,7 @@
         <link rel="shortcut icon" type="image/png" href="img/mobius.png"/>
         <link rel='stylesheet' href="css/pikaday.css" />
         <meta name="viewport" content="user-scalable=no, initial-scale=1, maximum-scale=1, minimum-scale=1, width=device-width">
+        <LINK REL="apple-touch-icon" HREF="img/mobius.png" type="image/png" />
         <?php 
         require_once("login.php");
 	    require_once("connection.php");


### PR DESCRIPTION
If an iphone user adds the pscs website to their home screen the image is now set to the mobius.
Here is a picture to prove it works:
![img_6143](https://cloud.githubusercontent.com/assets/6172938/7900897/930b71ce-0724-11e5-9e36-406226f97a51.jpg)
