### PR TITLE
fix year end errors

### DIFF
--- a/index.php
+++ b/index.php
@@ -93,7 +93,17 @@
 		}
 	    $current_users_result = $db_server->query($studentquery);
 		
-	    
+	    // get dates
+                $globals_query = "SELECT * FROM globals";
+                $globals_result = $db_server->query($globals_query);
+                $globals_data = $globals_result->fetch_array();
+				$getendDate = new DateTime($globals_data['enddate']);
+				$getstartDate = new DateTime($globals_data['startdate']);
+				date_add($getstartDate, date_interval_create_from_date_string('1 day'));
+				date_add($getendDate, date_interval_create_from_date_string('-1 day'));
+				$startDate = $getstartDate->format('Y-m-d H:i:s');
+				$endDate = $getendDate->format('Y-m-d H:i:s');
+				
 	// changestatus functions to create new entries in the database
 	//each only triggers if each field is correctly filled out, and the corresponding submit button has been pressed
 	
@@ -275,6 +285,7 @@ if (validTime($_POST['offtime'])){
 										 JOIN statusdata ON events.statusid = statusdata.statusid
 										 RIGHT JOIN studentdata ON events.studentid = studentdata.studentid
 										 WHERE studentdata.studentid = $current_student_id[studentid] 
+										 AND timestamp BETWEEN '$startDate' AND '$endDate' 
 										 ORDER BY timestamp DESC
 										 LIMIT 1")
 										 or die(mysqli_error($db_server));
@@ -288,7 +299,7 @@ if (validTime($_POST['offtime'])){
 			echo "</pre>";*/
 			$fieldTripArray = array();
 			$uniqueFacil = array();
-			for ($i = 0; $i <= count($student_data_array); $i++) {
+			for ($i = 0; $i < count($student_data_array); $i++) {
 				if ($student_data_array[$i]['statusname'] == "Field Trip") {
 					if (!in_array($student_data_array[$i]['info'], $uniqueFacil)) {
 						array_push($uniqueFacil, $student_data_array[$i]['info']);

--- a/user.php
+++ b/user.php
@@ -51,6 +51,17 @@
 		array_push ($facilitators, $fac_row[0]);
     }
 
+		    // get dates
+                $globals_query = "SELECT * FROM globals";
+                $globals_result = $db_server->query($globals_query);
+                $globals_data = $globals_result->fetch_array();
+				$getendDate = new DateTime($globals_data['enddate']);
+				$getstartDate = new DateTime($globals_data['startdate']);
+				date_add($getstartDate, date_interval_create_from_date_string('1 day'));
+				date_add($getendDate, date_interval_create_from_date_string('-1 day'));
+				$startDate = $getstartDate->format('Y-m-d H:i:s');
+				$endDate = $getendDate->format('Y-m-d H:i:s');
+				
 // if another date has not been chosen, and the submit button has been pressed, change status
 if(empty($_POST['otherdate'])){
 if (!empty($_POST)){
@@ -243,25 +254,25 @@ if (!empty($_POST)){
 	$rowcnt=$rowcnt-1;
 	}
 	//query to get current status and another to convert the status id to the clear text statusname
-	$info = $db_server->query("SELECT statusid FROM events WHERE studentid = '".$id."'ORDER BY timestamp DESC LIMIT 1");
+	$info = $db_server->query("SELECT statusid FROM events WHERE studentid = '".$id."' AND timestamp BETWEEN '$startDate' AND '$endDate' ORDER BY timestamp DESC LIMIT 1");
 	$rowdata=mysqli_fetch_row($info);
 	$currentstatusid=$rowdata[0];
 	$convert = $db_server->query("SELECT statusname FROM statusdata WHERE statusid = '".$currentstatusid."'");
 	$currentstatus=mysqli_fetch_row($convert);
 	
 	//query returntime
-	$getreturn = $db_server->query("SELECT returntime FROM events WHERE studentid = '".$id."'ORDER BY timestamp DESC LIMIT 1");
+	$getreturn = $db_server->query("SELECT returntime FROM events WHERE studentid = '".$id."' AND timestamp BETWEEN '$startDate' AND '$endDate' ORDER BY timestamp DESC LIMIT 1");
 	$returntime=mysqli_fetch_row($getreturn);
 	$finalreturn=$returntime[0];
 	$returntimeobject = new DateTime($finalreturn);
 	
 	//query info
-	$getwith = $db_server->query("SELECT info FROM events WHERE studentid = '".$id."'ORDER BY timestamp DESC LIMIT 1");
+	$getwith = $db_server->query("SELECT info FROM events WHERE studentid = '".$id."' AND timestamp BETWEEN '$startDate' AND '$endDate' ORDER BY timestamp DESC LIMIT 1");
 	$withrow=mysqli_fetch_row($getwith);
 	$finalwith=$withrow[0];
 	
 	//query timestamp
-	$getdate = $db_server->query("SELECT timestamp FROM events WHERE studentid = '".$id."'ORDER BY timestamp DESC LIMIT 1");
+	$getdate = $db_server->query("SELECT timestamp FROM events WHERE studentid = '".$id."' AND timestamp BETWEEN '$startDate' AND '$endDate' ORDER BY timestamp DESC LIMIT 1");
 	$datedata=mysqli_fetch_row($getdate);
 	$currentdate=$datedata[0];
 	

--- a/viewreports.php
+++ b/viewreports.php
@@ -636,6 +636,19 @@ echo "<br>";
 <?php
 }
 }
+
+//globals query
+$globalsquery = "SELECT * FROM globals";
+$globals_result = $db_server->query($globalsquery);
+$globalsdata = $globals_result->fetch_array();
+$startdateforpicker = $globalsdata['startdate'];
+$enddateforpicker = $globalsdata['enddate'];
+$startdateforpicker = new DateTime($startdateforpicker);
+$enddateforpicker = new DateTime($enddateforpicker);
+$startdateforpicker = $startdateforpicker->format('Y/m/d');
+$enddateforpicker = $enddateforpicker->format('Y/m/d');
+echo $startdateforpicker . " <br> " . $enddateforpicker;
+
 ?>
 </div>
 </form>
@@ -645,8 +658,8 @@ echo "<br>";
                jQuery(this).find('.xdsoft_date.xdsoft_weekend')
                   .addClass('xdsoft_disabled');
             },
-            minDate:'2014/09/08',
-            maxDate:'2015/6/17', // SET THESE TO GLOBALS FOR START DATE AND END DATE
+            minDate:<?php echo(json_encode($startdateforpicker)); ?>,
+            maxDate:<?php echo(json_encode($enddateforpicker)); ?>,
             format:'Y-m-d H:i:s',
 			defaultTime:'8:00', 
             step: 5,
@@ -658,8 +671,8 @@ echo "<br>";
                jQuery(this).find('.xdsoft_date.xdsoft_weekend')
                   .addClass('xdsoft_disabled');
             },
-            minDate:'2014/09/08',
-            maxDate:'2015/6/17', // SET THESE TO GLOBALS FOR START DATE AND END DATE
+            minDate:<?php echo(json_encode($startdateforpicker)); ?>,
+            maxDate:<?php echo(json_encode($enddateforpicker)); ?>,
             format:'Y-m-d H:i:s',
 			defaultTime:'15:30', 
             step: 5,

--- a/viewreports.php
+++ b/viewreports.php
@@ -415,11 +415,10 @@ $offsiteMin_used = $offsitehours_used % 60;
 if ($daystillend > 0) {
 $minutesperday = floor($offsitehours_remaining / $daystillend);
 echo "<p class='reporttext'> You have " . $minutesperday . " minutes of offsite per day.</p>";
+echo "<p class='reporttext'> School days left: " . $daystillend. "</p>";
 } else {
 echo "<p class='reporttext'> The school year has ended.</p>";
 }
-
-echo "<p class='reporttext'> School days left: " . $daystillend. "</p>";
 
 echo "<p class='reporttext'> You have used " . $offsiteHrs_used . " hours and " . $offsiteMin_used . " minutes of your offsite time.</p>";
 


### PR DESCRIPTION
I updated all of the queries to only select events with a timestamp between the globals.startdate - 1 and globals.enddate + 1. I also fixed the minutes per day to work as if there were one day left, which makes some of the minutes per day absurd (sofia , 7584 mins per day), but I think that this is the only accurate mins perday depiction and allows the leaderboards to be sorted. Also, no events made after the end of the school year will show up as changes on the main page. 

@nwarmenh , if you have issues with this, I will try to fix them ASAP, but I am on a family trip atm and may be afk.