### PR TITLE
added handling for midyear students on view reports

### DIFF
--- a/function.php
+++ b/function.php
@@ -371,7 +371,7 @@ function statconvert($id)
 {
     global $db_server;
     if (empty($id)){
-        $id = 8;
+        $id = 1;
     }
     $query = $db_server->query("SELECT statusname FROM statusdata WHERE statusid = $id");
     $tempvar = $query->fetch_assoc();

--- a/function.php
+++ b/function.php
@@ -370,6 +370,9 @@ function idToLastName($id)
 function statconvert($id)
 {
     global $db_server;
+    if (empty($id)){
+        $id = 8;
+    }
     $query = $db_server->query("SELECT statusname FROM statusdata WHERE statusid = $id");
     $tempvar = $query->fetch_assoc();
     $name = $tempvar['statusname'];


### PR DESCRIPTION
View reports calls a function to get the id of the event before the current event. This makes the event before it be 'present' in if no event exists, as this only happens with midear students.